### PR TITLE
fix: changed call close function name to hangup in docs

### DIFF
--- a/apps/docs/reference/call.md
+++ b/apps/docs/reference/call.md
@@ -90,7 +90,6 @@ interface ICall {
   removeTrack(track: MediaStreamTrack): void;
 
   // Close the session.
-  close(): void;
+  hangup(): void;
 }
 ```
-


### PR DESCRIPTION
The `hangup` option was still named `close` in the docs.