### PR TITLE
Updating Docs: Separating Examples, Updating Getting Started Page

### DIFF
--- a/apps/docs/.vitepress/config.mts
+++ b/apps/docs/.vitepress/config.mts
@@ -17,6 +17,7 @@ export default defineConfig({
         base: "/reference/",
         items: referenceSidebar(),
       },
+
     },
 
     socialLinks: [
@@ -40,6 +41,8 @@ function guideSidebar(): DefaultTheme.SidebarItem[] {
       items: [
         { text: "What is Artico?", link: "what-is-artico" },
         { text: "Getting Started", link: "getting-started" },
+        { text: "Voice / Video Example", link: "call-example" },
+        { text: "Room Example", link: "room-example" },
       ],
     },
   ];

--- a/apps/docs/guide/call-example.md
+++ b/apps/docs/guide/call-example.md
@@ -2,7 +2,7 @@
 This documentation is still a work-in-progress.
 :::
 
-## Voice / Video Example
+# Voice / Video Example
 
 The following example shows how to connect two peers and share audio/video/data between them:
 
@@ -68,12 +68,15 @@ rtco.on("open", (id) => {
       })
       .then((stream) => {
         // send stream to Peer 1 with metadata indicating type of stream
-        call.addStream(stream, JSON.stringify({
-          type: "camera",
-        }));
+        call.addStream(
+          stream,
+          JSON.stringify({
+            type: "camera",
+          })
+        );
       })
       .catch(console.error);
-  })
+  });
 });
 
 // ...

--- a/apps/docs/guide/call-example.md
+++ b/apps/docs/guide/call-example.md
@@ -1,0 +1,80 @@
+::: warning
+This documentation is still a work-in-progress.
+:::
+
+## Voice / Video Example
+
+The following example shows how to connect two peers and share audio/video/data between them:
+
+#### Peer 1
+
+```ts
+import { Artico } from "@rtco/client";
+
+const rtco = new Artico();
+
+rtco.on("open", (id: string) => {
+  // We're now connected to the signaling server. `id` refers to the unique ID that
+  // is currently assigned to this peer, so remote peers can connect to us.
+  console.log("Connected to signaling server with peer ID:", id);
+});
+
+rtco.on("close", () => {
+  console.log("Connection to signaling server is now closed.");
+});
+
+rtco.on("error", (err) => {
+  console.log("Artico error:", err);
+});
+
+rtco.on("call", (call) => {
+  // The calling peer can link any metadata string to a call.
+  const meta = JSON.parse(call.metadata);
+  const remotePeerName = meta.name;
+
+  console.log(`Call from ${remotePeerName}...`);
+
+  // Answer the call.
+  call.answer();
+
+  call.on("stream", (stream, metadata) => {
+    // Stream was added by remote peer, so display it somehow.
+    // `metadata` can be appended by the remote peer when adding the stream.
+  });
+});
+```
+
+#### Peer 2
+
+```ts
+import { Artico } from "@rtco/client";
+
+const remotePeerId = "<ID of target remote peer>";
+
+const rtco = new Artico();
+
+rtco.on("open", (id) => {
+  console.log("Connected to signaling server with peer ID:", id);
+
+  const call = rtco.call(remotePeerId);
+
+  call.on("open", () => {
+    // Session is now established between you and your peer.
+    // Let's send Peer 1 our audio/video...
+    navigator.mediaDevices
+      .getUserMedia({
+        video: true,
+        audio: true,
+      })
+      .then((stream) => {
+        // send stream to Peer 1 with metadata indicating type of stream
+        call.addStream(stream, JSON.stringify({
+          type: "camera",
+        }));
+      })
+      .catch(console.error);
+  })
+});
+
+// ...
+```

--- a/apps/docs/guide/getting-started.md
+++ b/apps/docs/guide/getting-started.md
@@ -44,9 +44,9 @@ const rtco = new Artico();
 
 ### Setup with Custom ID
 
-::: warning
-Creating custom ID with the Out-of-the-box Signaling can cause ID conflicts. This will return a bad request error (400) when it happens
-:::
+You can request a specific peer ID. If you do, Artico will attempt to register such ID with the signaling server. If not available, Artico will emit an Error with the message "invalid-id".
+
+:::Warning: It is recommended that you let Artico assign you a random ID, since IDs should be universally unique within Artico's signaling network.:::
 
 ```js
 import { Artico } from "@rtco/client";
@@ -59,7 +59,7 @@ const rtco = new Artico({
 
 ## Connection
 
-Connections can be created with the `call()` function in the `Artico` object and the connections can be accepted using the `answer()` method. But before that, the `open` event should be listened to, to ensure that the connection to the signaling server is established.
+Connections can be created with the `call()` function in the `Artico` object and the connections can be accepted using the `answer()` method. But before that, the `open` event should be listened to, to ensure that the signalling is ready.
 
 ### Request Connection
 

--- a/apps/docs/guide/getting-started.md
+++ b/apps/docs/guide/getting-started.md
@@ -50,11 +50,16 @@ You can request a specific peer ID. If you do, Artico will attempt to register s
 
 ```js
 import { Artico } from "@rtco/client";
-import { v4 } from "uuid";
 
 const rtco = new Artico({
-  id: v4.slice(0, 5), // creates a 5 characted ID
+  id: "my-custom-id"
 });
+
+rtco.on("error", (err: Error) => {
+  if (err.message === 'id-taken') {
+    console.log("ID is taken!");
+  }
+})
 ```
 
 ## Connection

--- a/apps/docs/guide/getting-started.md
+++ b/apps/docs/guide/getting-started.md
@@ -14,6 +14,7 @@ For the purposes of the guide, we will demonstrate how to use Artico's client li
 Please refer to the documentation to learn how to use Artico's libraries in a way that fits your application requirements.
 
 ::: code-group
+
 ```sh [npm]
 $ npm install @rtco/client
 ```
@@ -29,8 +30,8 @@ $ pnpm install @rtco/client
 ```sh [bun]
 $ bun add @rtco/client
 ```
-:::
 
+:::
 
 ## Setup
 
@@ -38,10 +39,11 @@ $ bun add @rtco/client
 
 ```js
 import { Artico } from "@rtco/client";
-const rtco = new Artico()
+const rtco = new Artico();
 ```
 
 ### Setup with Custom ID
+
 ::: warning
 Creating custom ID with the Out-of-the-box Signaling can cause ID conflicts. This will return a bad request error (400) when it happens
 :::
@@ -51,82 +53,84 @@ import { Artico } from "@rtco/client";
 import { v4 } from "uuid";
 
 const rtco = new Artico({
-    id: v4.slice(0, 5) // creates a 5 characted ID
-})
+  id: v4.slice(0, 5), // creates a 5 characted ID
+});
 ```
 
 ## Connection
 
-Connections can be created with the `call()` function in the `Artico` object and the connections can be accepted using the `answer()` method.
+Connections can be created with the `call()` function in the `Artico` object and the connections can be accepted using the `answer()` method. But before that, the `open` event should be listened to, to ensure that the connection to the signaling server is established.
 
 ### Request Connection
 
 ```js
-rtco.call("<Remote Peer ID>");
+rtco.on("open", (id) => {
+  rtco.call("<Remote Peer ID>");
+});
 ```
 
 ### Accept Connection
-Incomming requests are emitted as `call` events and can be listened through the `Artico` object. 
+
+Incomming requests are emitted as `call` events and can be listened through the `Artico` object.
 
 ```js
 rtco.on("call", (call) => {
   // accepting call
   call.answer();
-})
+});
 ```
 
 ## Basic Connection Example
 
 #### Peer 1 (Calling Peer)
+
 ```js
-import { Artico } from "@rtco/client"
+import { Artico } from "@rtco/client";
 
-const rtco = new Artico()
-const remoteID = "<Remote Peer ID>" // Ideally taken from an input field, or other source..
+const rtco = new Artico();
+const remoteID = "<Remote Peer ID>"; // Ideally taken from an input field, or other source..
 
-const call = rtco.call(remoteID, { username: "<someusername>" }) // The second attribute is the metadata that can be passed to the connection
+rtco.on("open", (id) => {
+  console.log("Connected to signaling server with peer ID:", id);
 
-call.on("open", () => { // Triggered when connection is established
-  console.log("Connection established to ", call.target) // Target is the remote ID
-  call.send("Hello World!!") // Used to send data to connected Peer
+  const call = rtco.call(remoteID, { username: "<someusername>" }); // The second attribute is the metadata that can be passed to the connection
 
-  call.on("data", (data) => {
-    console.log("Data Recieved : ", data)
-  })
+  call.on("open", () => {
+    // Triggered when connection is established
+    console.log("Connection established to ", call.target); // Target is the remote ID
+    call.send("Hello World!!"); // Used to send data to connected Peer
 
-  call.on("close", () => {
-    console.log("Connection Closed")
-  })
-})
-
+    call.on("close", () => {
+      console.log("Connection Closed");
+    });
+  });
+});
 ```
 
 #### Peer 2 (Receiving Peer)
-```js
-import { Artico } from "@rtco/client"
 
-const rtco = new Artico()
+```js
+import { Artico } from "@rtco/client";
+
+const rtco = new Artico();
 
 rtco.on("call", (call) => {
-  const { metadata } = call
+  const { metadata } = call;
 
-  console.log("Incoming call from: ", metadata.username)
-  call.answer()
+  console.log("Incoming call from: ", metadata.username);
+  call.answer();
 
-  call.on("open", () => { // Triggered when connection is established
-    console.log("Connection established to ", call.target) // Target is the remote ID
-  })
+  call.on("open", () => {
+    // Triggered when connection is established
+    console.log("Connection established to ", call.target); // Target is the remote ID
+  });
 
   call.on("data", (data) => {
-    console.log("Data Recieved : ", data)
-  })
+    console.log("Data Recieved : ", data);
+  });
 
   call.on("close", () => {
-    console.log("Connection Closed")
-  })
-})
+    console.log("Connection Closed");
+  });
+});
 ```
-
-
-
-

--- a/apps/docs/guide/getting-started.md
+++ b/apps/docs/guide/getting-started.md
@@ -44,9 +44,11 @@ const rtco = new Artico();
 
 ### Setup with Custom ID
 
-You can request a specific peer ID. If you do, Artico will attempt to register such ID with the signaling server. If not available, Artico will emit an Error with the message "invalid-id".
+You can request a specific peer ID. If you do, Artico will attempt to register such ID with the signaling server. If not available, Artico will emit an Error with the message "id-taken".
 
-:::Warning: It is recommended that you let Artico assign you a random ID, since IDs should be universally unique within Artico's signaling network.:::
+::: tip
+It is recommended that you let Artico assign you a random ID, since IDs should be universally unique within Artico's signaling network.
+:::
 
 ```js
 import { Artico } from "@rtco/client";

--- a/apps/docs/guide/getting-started.md
+++ b/apps/docs/guide/getting-started.md
@@ -32,128 +32,101 @@ $ bun add @rtco/client
 :::
 
 
-## Call Example
+## Setup
 
-The following example shows how to connect two peers and share audio/video/data between them:
+### Basic Setup
 
-#### Peer 1
-
-```ts
+```js
 import { Artico } from "@rtco/client";
+const rtco = new Artico()
+```
 
-const rtco = new Artico();
+### Setup with Custom ID
+::: warning
+Creating custom ID with the Out-of-the-box Signaling can cause ID conflicts. This will return a bad request error (400) when it happens
+:::
 
-rtco.on("open", (id: string) => {
-  // We're now connected to the signaling server. `id` refers to the unique ID that
-  // is currently assigned to this peer, so remote peers can connect to us.
-  console.log("Connected to signaling server with peer ID:", id);
-});
+```js
+import { Artico } from "@rtco/client";
+import { v4 } from "uuid";
 
-rtco.on("close", () => {
-  console.log("Connection to signaling server is now closed.");
-});
+const rtco = new Artico({
+    id: v4.slice(0, 5) // creates a 5 characted ID
+})
+```
 
-rtco.on("error", (err) => {
-  console.log("Artico error:", err);
-});
+## Connection
+
+Connections can be created with the `call()` function in the `Artico` object and the connections can be accepted using the `answer()` method.
+
+### Request Connection
+
+```js
+rtco.call("<Remote Peer ID>");
+```
+
+### Accept Connection
+Incomming requests are emitted as `call` events and can be listened through the `Artico` object. 
+
+```js
+rtco.on("call", (call) => {
+  // accepting call
+  call.answer();
+})
+```
+
+## Basic Connection Example
+
+#### Peer 1 (Calling Peer)
+```js
+import { Artico } from "@rtco/client"
+
+const rtco = new Artico()
+const remoteID = "<Remote Peer ID>" // Ideally taken from an input field, or other source..
+
+const call = rtco.call(remoteID, { username: "<someusername>" }) // The second attribute is the metadata that can be passed to the connection
+
+call.on("open", () => { // Triggered when connection is established
+  console.log("Connection established to ", call.target) // Target is the remote ID
+  call.send("Hello World!!")
+
+  call.on("data", (data) => {
+    console.log("Data Recieved : ", data)
+  })
+
+  call.on("close", () => {
+    console.log("Connection Closed")
+  })
+})
+
+```
+
+#### Peer 2 (Receiving Peer)
+```js
+import { Artico } from "@rtco/client"
+
+const rtco = new Artico()
 
 rtco.on("call", (call) => {
-  // The calling peer can link any metadata string to a call.
-  const meta = JSON.parse(call.metadata);
-  const remotePeerName = meta.name;
+  const { metadata } = call
 
-  console.log(`Call from ${remotePeerName}...`);
+  console.log("Incoming call from: ", metadata.username)
+  call.answer()
 
-  // Answer the call.
-  call.answer();
-
-  call.on("stream", (stream, metadata) => {
-    // Stream was added by remote peer, so display it somehow.
-    // `metadata` can be appended by the remote peer when adding the stream.
-  });
-});
-```
-
-#### Peer 2
-
-```ts
-import { Artico } from "@rtco/client";
-
-const remotePeerId = "<ID of target remote peer>";
-
-const rtco = new Artico();
-
-rtco.on("open", (id) => {
-  console.log("Connected to signaling server with peer ID:", id);
-
-  const call = rtco.call(remotePeerId);
-
-  call.on("open", () => {
-    // Session is now established between you and your peer.
-    // Let's send Peer 1 our audio/video...
-    navigator.mediaDevices
-      .getUserMedia({
-        video: true,
-        audio: true,
-      })
-      .then((stream) => {
-        // send stream to Peer 1 with metadata indicating type of stream
-        call.addStream(stream, JSON.stringify({
-          type: "camera",
-        }));
-      })
-      .catch(console.error);
+  call.on("open", () => { // Triggered when connection is established
+    console.log("Connection established to ", call.target) // Target is the remote ID
   })
-});
 
-// ...
+  call.on("data", (data) => {
+    console.log("Data Recieved : ", data)
+  })
+
+  call.on("close", () => {
+    console.log("Connection Closed")
+  })
+})
 ```
 
-## Room Example
 
-Artico provides a way to connect to a "room" of peers, instead of calling just one.
-All peers in the same room will be connected between them automatically by Artico.
-Here's an example of a peer joining a room and sharing their audio/video with others in the same room.
 
-```ts
-import { Artico } from "@rtco/client";
 
-const rtco = new Artico();
-
-rtco.on("open", (id) => {
-  // Connected to signaling server.
-  const room = rtco.join("<target-room-id>");
-
-  room.on("join", (peerId) => {
-    console.log(`Peer ${peerId} has joined the room!`);
-  });
-
-  room.on("leave", (peerId) => {
-    console.log(`Peer ${peerId} has left the room!`);
-  });
-
-  room.on("stream", (stream, peerId) => {
-    console.log(`Peer ${peerId} has shared stream ${stream.id}!`);
-  });
-
-  // ...
-
-  navigator.mediaDevices
-    .getUserMedia({
-      video: true,
-      audio: true,
-    })
-    .then((stream) => {
-      // Send stream to everyone in the room, or...
-      room.addStream(stream);
-
-      // Send stream to specific peers in the room
-      room.addStream(
-        stream,
-        ["<target-peer-id-1>", "<target-peer-id-2>"],
-        "<optional-metadata>",
-      );
-    })
-    .catch(console.error);
-});
-```

--- a/apps/docs/guide/getting-started.md
+++ b/apps/docs/guide/getting-started.md
@@ -88,7 +88,7 @@ const call = rtco.call(remoteID, { username: "<someusername>" }) // The second a
 
 call.on("open", () => { // Triggered when connection is established
   console.log("Connection established to ", call.target) // Target is the remote ID
-  call.send("Hello World!!")
+  call.send("Hello World!!") // Used to send data to connected Peer
 
   call.on("data", (data) => {
     console.log("Data Recieved : ", data)

--- a/apps/docs/guide/room-example.md
+++ b/apps/docs/guide/room-example.md
@@ -1,0 +1,48 @@
+# Room Example
+
+Artico provides a way to connect to a "room" of peers, instead of calling just one.
+All peers in the same room will be connected between them automatically by Artico.
+Here's an example of a peer joining a room and sharing their audio/video with others in the same room.
+
+```ts
+import { Artico } from "@rtco/client";
+
+const rtco = new Artico();
+
+rtco.on("open", (id) => {
+  // Connected to signaling server.
+  const room = rtco.join("<target-room-id>");
+
+  room.on("join", (peerId) => {
+    console.log(`Peer ${peerId} has joined the room!`);
+  });
+
+  room.on("leave", (peerId) => {
+    console.log(`Peer ${peerId} has left the room!`);
+  });
+
+  room.on("stream", (stream, peerId) => {
+    console.log(`Peer ${peerId} has shared stream ${stream.id}!`);
+  });
+
+  // ...
+
+  navigator.mediaDevices
+    .getUserMedia({
+      video: true,
+      audio: true,
+    })
+    .then((stream) => {
+      // Send stream to everyone in the room, or...
+      room.addStream(stream);
+
+      // Send stream to specific peers in the room
+      room.addStream(
+        stream,
+        ["<target-peer-id-1>", "<target-peer-id-2>"],
+        "<optional-metadata>",
+      );
+    })
+    .catch(console.error);
+});
+```

--- a/apps/docs/guide/room-example.md
+++ b/apps/docs/guide/room-example.md
@@ -1,3 +1,7 @@
+::: warning
+This documentation is still a work-in-progress.
+:::
+
 # Room Example
 
 Artico provides a way to connect to a "room" of peers, instead of calling just one.


### PR DESCRIPTION
Separated the getting started page into 2 extra pages, Voice/Video example and Room example (No example code changed).

Changed the Getting started page to include more content as to match the title. 