### PR TITLE
Expose websocket connection

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "artico",

--- a/packages/client/src/artico.ts
+++ b/packages/client/src/artico.ts
@@ -47,7 +47,7 @@ interface IArtico {
 
 export class Artico extends EventEmitter<ArticoEvents> implements IArtico {
   #logger: Logger;
-  #signaling: Signaling;
+  signaling: Signaling;
   #calls = new Map<string, Call>();
   #rtcConfig?: RTCConfiguration;
 
@@ -57,33 +57,33 @@ export class Artico extends EventEmitter<ArticoEvents> implements IArtico {
     this.#logger = new Logger("[artico]", options?.debug ?? LogLevel.Errors);
     this.#logger.debug("new Artico:", options);
 
-    this.#signaling =
+    this.signaling =
       options?.signaling ??
       new SocketSignaling({ debug: this.#logger.logLevel, id: options?.id });
     this.#rtcConfig = options?.rtcConfig;
 
     this.#setupSignalingListeners();
 
-    this.#signaling.connect();
+    this.signaling.connect();
   }
 
   get id() {
-    return this.#signaling.id;
+    return this.signaling.id;
   }
 
   get state() {
-    return this.#signaling.state;
+    return this.signaling.state;
   }
 
   call = (target: string, metadata?: string) => {
     this.#logger.debug(`call(${target}, ${metadata})`);
 
-    if (this.#signaling.state !== "ready") {
+    if (this.signaling.state !== "ready") {
       throw new Error("Cannot call peers until signaling is ready.");
     }
 
     const call = new Call({
-      signaling: this.#signaling,
+      signaling: this.signaling,
       debug: this.#logger.logLevel,
       target,
       metadata,
@@ -96,13 +96,13 @@ export class Artico extends EventEmitter<ArticoEvents> implements IArtico {
   join = (roomId: string, metadata?: string) => {
     this.#logger.debug("join:", roomId, metadata);
 
-    if (this.#signaling.state !== "ready") {
+    if (this.signaling.state !== "ready") {
       throw new Error("Cannot join room until signaling is ready.");
     }
 
     return new Room({
       debug: this.#logger.logLevel,
-      signaling: this.#signaling,
+      signaling: this.signaling,
       roomId,
       metadata,
     });
@@ -112,22 +112,22 @@ export class Artico extends EventEmitter<ArticoEvents> implements IArtico {
     this.#logger.debug("close");
     this.removeAllListeners();
     this.#removeSignalingListeners();
-    this.#signaling.disconnect();
+    this.signaling.disconnect();
     this.emit("close");
   };
 
   #setupSignalingListeners() {
-    this.#signaling.on("error", this.#handleError.bind(this));
-    this.#signaling.on("connect", this.#handleConnect.bind(this));
-    this.#signaling.on("disconnect", this.#handleDisconnect.bind(this));
-    this.#signaling.on("signal", this.#handleSignal.bind(this));
+    this.signaling.on("error", this.#handleError.bind(this));
+    this.signaling.on("connect", this.#handleConnect.bind(this));
+    this.signaling.on("disconnect", this.#handleDisconnect.bind(this));
+    this.signaling.on("signal", this.#handleSignal.bind(this));
   }
 
   #removeSignalingListeners() {
-    this.#signaling.off("error", this.#handleError.bind(this));
-    this.#signaling.off("connect", this.#handleConnect.bind(this));
-    this.#signaling.off("disconnect", this.#handleDisconnect.bind(this));
-    this.#signaling.off("signal", this.#handleSignal.bind(this));
+    this.signaling.off("error", this.#handleError.bind(this));
+    this.signaling.off("connect", this.#handleConnect.bind(this));
+    this.signaling.off("disconnect", this.#handleDisconnect.bind(this));
+    this.signaling.off("signal", this.#handleSignal.bind(this));
   }
 
   #handleError(err: Error) {
@@ -155,7 +155,7 @@ export class Artico extends EventEmitter<ArticoEvents> implements IArtico {
 
       const call = new Call({
         debug: this.#logger.logLevel,
-        signaling: this.#signaling,
+        signaling: this.signaling,
         metadata: msg.metadata,
         signal: msg,
         rtcConfig: this.#rtcConfig,

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -4,3 +4,4 @@ export * from "~/signaling/socket-io";
 export type { Call } from "~/call";
 export type { Room } from "~/room";
 export { Artico as default } from "~/artico";
+export type { Socket } from "socket.io-client";

--- a/packages/client/src/signaling/index.ts
+++ b/packages/client/src/signaling/index.ts
@@ -1,4 +1,5 @@
 import type { EventEmitter } from "eventemitter3";
+import { Socket } from "socket.io-client";
 
 import type { Signal } from "@rtco/peer";
 
@@ -36,6 +37,7 @@ export type SignalingState =
 export interface Signaling extends EventEmitter<SignalingEvents> {
   get id(): string;
   get state(): SignalingState;
+  socket: Socket;
 
   connect(): void;
   disconnect(): void;

--- a/packages/client/src/signaling/socket-io.ts
+++ b/packages/client/src/signaling/socket-io.ts
@@ -14,6 +14,7 @@ import type {
 import { randomId } from "~/util";
 
 export interface SocketSignalingOptions {
+  socketQuery: Record<string, string>;
   debug: LogLevel;
   url: string;
   id: string;
@@ -26,6 +27,7 @@ export class SocketSignaling
   #logger: Logger;
   #state: SignalingState = "disconnected";
   socket: Socket;
+
   #url: string;
   #id: string;
 
@@ -37,13 +39,21 @@ export class SocketSignaling
 
     this.#url = options?.url ?? "https://0.artico.dev:443";
     this.#id = options?.id ?? randomId();
+    const query: Record<string, string> = {};
+
+    if (options?.socketQuery) {
+      Object.assign(query, options.socketQuery);
+    }
+
+    query.id = this.#id;
 
     this.socket = io(this.#url, {
       autoConnect: false,
+      reconnection: true,
+      reconnectionDelay: 1000,
+      reconnectionDelayMax: 2000,
       transports: ["websocket"],
-      query: {
-        id: this.#id,
-      },
+      query,
     });
   }
 

--- a/packages/client/src/signaling/socket-io.ts
+++ b/packages/client/src/signaling/socket-io.ts
@@ -25,7 +25,7 @@ export class SocketSignaling
 {
   #logger: Logger;
   #state: SignalingState = "disconnected";
-  #socket: Socket;
+  socket: Socket;
   #url: string;
   #id: string;
 
@@ -38,7 +38,7 @@ export class SocketSignaling
     this.#url = options?.url ?? "https://0.artico.dev:443";
     this.#id = options?.id ?? randomId();
 
-    this.#socket = io(this.#url, {
+    this.socket = io(this.#url, {
       autoConnect: false,
       transports: ["websocket"],
       query: {
@@ -59,13 +59,13 @@ export class SocketSignaling
     this.#logger.debug(`connect(${this.#id})`);
     this.#state = "connecting";
     this.#setupSocketListeners();
-    this.#socket.connect();
+    this.socket.connect();
   }
 
   disconnect() {
     this.#logger.debug("disconnect()");
     this.#removeSocketListeners();
-    this.#socket.disconnect();
+    this.socket.disconnect();
     this.#state = "disconnected";
   }
 
@@ -78,7 +78,7 @@ export class SocketSignaling
       return;
     }
     this.#logger.debug("tx signal:", msg);
-    this.#socket.emit("signal", msg);
+    this.socket.emit("signal", msg);
   }
 
   join(roomId: string, metadata?: string) {
@@ -90,21 +90,21 @@ export class SocketSignaling
       return;
     }
     this.#logger.debug(`join(${roomId}, ${metadata})`);
-    this.#socket.emit("join", roomId, metadata);
+    this.socket.emit("join", roomId, metadata);
   }
 
   #setupSocketListeners() {
-    this.#socket.on("connect", this.#onSockerConnect.bind(this));
-    this.#socket.on("disconnect", this.#onSocketDisconnect.bind(this));
-    this.#socket.on("connect_error", this.#onSocketConnectError.bind(this));
-    this.#socket.on("open", this.#onSocketOpen.bind(this));
-    this.#socket.on("error", this.#onSocketError.bind(this));
-    this.#socket.on("signal", this.#onSocketSignal.bind(this));
-    this.#socket.on("join", this.#onSocketJoin.bind(this));
+    this.socket.on("connect", this.#onSockerConnect.bind(this));
+    this.socket.on("disconnect", this.#onSocketDisconnect.bind(this));
+    this.socket.on("connect_error", this.#onSocketConnectError.bind(this));
+    this.socket.on("open", this.#onSocketOpen.bind(this));
+    this.socket.on("error", this.#onSocketError.bind(this));
+    this.socket.on("signal", this.#onSocketSignal.bind(this));
+    this.socket.on("join", this.#onSocketJoin.bind(this));
   }
 
   #removeSocketListeners() {
-    this.#socket.removeAllListeners();
+    this.socket.removeAllListeners();
   }
 
   #onSockerConnect() {
@@ -134,7 +134,7 @@ export class SocketSignaling
     this.#logger.debug("error:", msg);
     this.emit("error", new Error(msg));
     this.#removeSocketListeners();
-    this.#socket.disconnect();
+    this.socket.disconnect();
     this.#state = "disconnected";
     this.emit("disconnect");
   }


### PR DESCRIPTION
I created  a voice chat app where I need to keep a websocket connection open. Artico was not exposing the underlying socket.io connection so I modified the code and built a version that exposes it, now I am creating a PR for others who might need it as well.

Example code:
```javascript
const signaling = new SocketSignaling({ url: "https://freevoice.app:443" });
const peer = new Artico({ signaling });

const peers = {};
const users = new Map();

let socket;
/**
 * @type{import("./lib/rtco-client").Room}
 */
let room;
/**
 * @type{MediaStream}
 */
let localStream;
/**
 * @type{string}
 */
let roomId;
let muted = false;

peer.on("close", () => {
  console.log("Connection to signaling server is now closed.");
});

peer.on("error", (err) => {
  console.log("Artico error:", err);
});

peer.on("open", () => {
  peerId = peer.id;
  console.log("Artico connected", peerId);
  peer.on("call", function (call) {
    console.log(`Call from peer`);

    call.answer();

    call.on("open", () => {
      console.log("Connection established to ", call.target);
    });
    call.on("error", (err) => {
      console.error("Call error:", err);
    });

    call.on("stream", function (remoteStream, metadata) {
      startVoiceStream(call.target, remoteStream);
    });
  });

  socket = signaling.socket;

  socket.on("room-list", (rooms) => {
    allRooms = rooms;
    renderRooms(rooms);
  });

  socket.on("nickname-changed", ({ id, nickname }) => {
    if (!users.has(id)) return;

    users.set(id, nickname);
    renderUsers();
  });

  socket.on("room-users", (usersInRoom) => {
    usersInRoom.forEach(({ id, nickname }) => {
      users.set(id, nickname);
    });
    renderUsers();
  });

  socket.on("user-joined", async ({ id, nickname, peerId }) => {
    users.set(id, nickname);
    renderUsers();
  });

  socket.on("user-left", (id) => {
    peers[id]?.close();
    delete peers[id];
    users.delete(id);
    renderUsers();
  });
});
```