### PR TITLE
fix(server): stop retaining joined peers

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -42,7 +42,6 @@ export class ArticoServer implements IArticoServer {
   #httpServer?: HttpServerInstance;
   #server: Server;
   #peers = new Map<string, Socket>();
-  #rooms = new Map<string, Set<string>>();
 
   constructor(options?: Partial<ArticoServerOptions>) {
     this.#logger = new Logger("[artico]", options?.debug ?? LogLevel.Errors);
@@ -100,10 +99,6 @@ export class ArticoServer implements IArticoServer {
         this.#logger.debug(`peer ${id} joins room ${roomId}`);
         await socket.join(roomId);
         socket.broadcast.to(roomId).emit("join", roomId, id, metadata);
-        if (!this.#rooms.has(roomId)) {
-          this.#rooms.set(roomId, new Set());
-        }
-        this.#rooms.get(roomId)?.add(id);
       });
     });
   }


### PR DESCRIPTION
## Summary

Remove the unused `#rooms` index, which retains every joined room and peer after disconnection. Socket.IO already owns room membership and automatically removes sockets and empty rooms on disconnect, so this duplicate state is unnecessary and causes unbounded memory growth.

## Verification

- `bun run build --filter=@rtco/server`
- `bun run format` in `packages/server`
- verified the Socket.IO adapter has no rooms or socket indexes after disconnect