### PR TITLE
fix(client): isolate per-call failures in Room fan-out operations

### DIFF
--- a/packages/client/src/room.ts
+++ b/packages/client/src/room.ts
@@ -144,7 +144,16 @@ export class Room extends EventEmitter<RoomEvents> implements IRoom {
   }
 
   send(msg: string, target?: string | string[]) {
-    runEachCall(this.#calls, (call) => call.send(msg), target);
+    // Only calls that are ready at call time receive the message; pending or
+    // closed calls are skipped with no exception, queue, or later replay.
+    runEachCall(
+      this.#calls,
+      (call) => {
+        if (!call.ready) return;
+        call.send(msg);
+      },
+      target,
+    );
   }
 
   addStream(
@@ -152,9 +161,14 @@ export class Room extends EventEmitter<RoomEvents> implements IRoom {
     metadata?: string,
     target?: string | string[] | null,
   ) {
+    // Only calls that are ready at call time run the whole Call.addStream;
+    // pending calls receive no metadata and no stream, with no later replay.
     runEachCall(
       this.#calls,
-      (call) => call.addStream(stream, metadata),
+      (call) => {
+        if (!call.ready) return;
+        call.addStream(stream, metadata);
+      },
       target,
     );
   }

--- a/packages/client/src/room.ts
+++ b/packages/client/src/room.ts
@@ -6,6 +6,38 @@ import type { InSignalMessage, Signaling } from "~/signaling";
 import { Call } from "~/call";
 import { randomToken } from "~/util";
 
+/**
+ * Runs `operation` for every call selected by `target` (or every call when no
+ * target is given), isolating each call's failure so one throwing call never
+ * prevents the remaining calls from being attempted. The first captured value
+ * is rethrown as-is after all selected calls have been attempted — including
+ * falsy non-Error values — preserving the original thrown value and the
+ * caller's synchronous failure semantics.
+ */
+const runEachCall = <T>(
+  calls: ReadonlyMap<string, T>,
+  operation: (call: T, peerId: string) => void,
+  target?: string | string[] | null,
+) => {
+  const targets = target ? (Array.isArray(target) ? target : [target]) : null;
+  let firstError: { value: unknown } | undefined;
+
+  calls.forEach((call, peerId) => {
+    if (targets && !targets.includes(peerId)) {
+      return;
+    }
+    try {
+      operation(call, peerId);
+    } catch (error) {
+      firstError ??= { value: error };
+    }
+  });
+
+  if (firstError) {
+    throw firstError.value;
+  }
+};
+
 export interface RoomEvents {
   close: () => void;
 
@@ -112,12 +144,7 @@ export class Room extends EventEmitter<RoomEvents> implements IRoom {
   }
 
   send(msg: string, target?: string | string[]) {
-    const targets = target ? (Array.isArray(target) ? target : [target]) : null;
-    this.#calls.forEach((call, peerId) => {
-      if (!targets || targets.includes(peerId)) {
-        call.send(msg);
-      }
-    });
+    runEachCall(this.#calls, (call) => call.send(msg), target);
   }
 
   addStream(
@@ -125,21 +152,15 @@ export class Room extends EventEmitter<RoomEvents> implements IRoom {
     metadata?: string,
     target?: string | string[] | null,
   ) {
-    const targets = target ? (Array.isArray(target) ? target : [target]) : null;
-    this.#calls.forEach((call, peerId) => {
-      if (!targets || targets.includes(peerId)) {
-        call.addStream(stream, metadata);
-      }
-    });
+    runEachCall(
+      this.#calls,
+      (call) => call.addStream(stream, metadata),
+      target,
+    );
   }
 
   removeStream(stream: MediaStream, target?: string | string[]) {
-    const targets = target ? (Array.isArray(target) ? target : [target]) : null;
-    this.#calls.forEach((call, peerId) => {
-      if (!targets || targets.includes(peerId)) {
-        call.removeStream(stream);
-      }
-    });
+    runEachCall(this.#calls, (call) => call.removeStream(stream), target);
   }
 
   addTrack(
@@ -147,31 +168,27 @@ export class Room extends EventEmitter<RoomEvents> implements IRoom {
     stream: MediaStream,
     target?: string | string[],
   ) {
-    const targets = target ? (Array.isArray(target) ? target : [target]) : null;
-    this.#calls.forEach((call, peerId) => {
-      if (!targets || targets.includes(peerId)) {
-        call.addTrack(track, stream);
-      }
-    });
+    runEachCall(this.#calls, (call) => call.addTrack(track, stream), target);
   }
 
   removeTrack(track: MediaStreamTrack, target?: string | string[]) {
-    const targets = target ? (Array.isArray(target) ? target : [target]) : null;
-    this.#calls.forEach((call, peerId) => {
-      if (!targets || targets.includes(peerId)) {
-        call.removeTrack(track);
-      }
-    });
+    runEachCall(this.#calls, (call) => call.removeTrack(track), target);
   }
 
   #close = () => {
     this.#removeSignalingListeners();
-    this.#calls.forEach((call) => {
-      this.#removeCallListeners(call);
-      call.hangup();
-    });
-    this.emit("close");
-    this.removeAllListeners();
+    // Listener removal is a local unsubscribe and cannot fail; only hangup may
+    // fail, so every call is still attempted and the first failure is
+    // rethrown as-is after all hangups.
+    try {
+      runEachCall(this.#calls, (call) => {
+        this.#removeCallListeners(call);
+        call.hangup();
+      });
+    } finally {
+      this.emit("close");
+      this.removeAllListeners();
+    }
   };
 
   #setupSignalingListeners() {


### PR DESCRIPTION
`Room.send()` and the other fan-out methods iterate `#calls` in a bare `forEach`, so the first throwing `Call.send()` (e.g. `Connection is not established yet.` when a peer's DataChannel isn't open yet) aborts the loop and every later peer silently receives nothing.

This PR makes the fan-out ready-only and failure-isolated:

- `Room.send()` / `Room.addStream()` only invoke `Call.send()` / `Call.addStream()` on calls whose `ready` is `true` at call time. Pending or closed calls are skipped with no exception, no queue, and no later replay — an explicit new call is required once the peer becomes ready. `addStream` skips the whole `Call.addStream()` for pending calls: no stream-metadata message and no stream.
- Every selected ready call is still attempted even when one throws, and the first thrown value (including falsy non-Error values) is rethrown as-is after the loop, preserving the synchronous API and error semantics.
- `addTrack`, `removeTrack`, `removeStream`, and `#close` keep failure isolation without a readiness gate; the existing `Peer.send()` readiness guard is unchanged.
- No new Promise-based ready-send, FIFO, timeout/abort, capacity, backpressure, retry/outbox, new API, or queued state.

Regression tests: [test/room-call-failure-isolation](https://github.com/molvqingtai/artico/tree/test/room-call-failure-isolation) — mixed ready/pending fan-out, pending-first ordering, all-pending no-op, target matrix (undefined / string / string[] / unknown / []), whole-`addStream` skip with no late replay, and ready-call failure isolation with first-value rethrow.