### PR TITLE
fix(client): actually detach call listeners on removal

### DIFF
--- a/packages/client/src/room.ts
+++ b/packages/client/src/room.ts
@@ -245,13 +245,9 @@ export class Room extends EventEmitter<RoomEvents> implements IRoom {
   };
 
   #removeCallListeners = (call: Call) => {
-    call.off("open", this.#handleCallOpen.bind(this, call));
-    call.off("close", this.#handleCallClose.bind(this, call));
-    call.off("data", this.#handleCallData.bind(this, call));
-    call.off("stream", this.#handleCallStream.bind(this, call));
-    call.off("removestream", this.#handleCallRemoveStream.bind(this, call));
-    call.off("track", this.#handleCallTrack.bind(this, call));
-    call.off("removetrack", this.#handleCallRemoveTrack.bind(this, call));
+    // `off` with a fresh `.bind(...)` can never match the registered listener;
+    // detach every Call listener at once instead.
+    call.removeAllListeners();
   };
 
   #handleCallOpen = (call: Call) => {


### PR DESCRIPTION
`#removeCallListeners` calls `off()` with a fresh `.bind(...)` each time. Since `bind` returns a new function object per call, `off` never matches the registered listener and silently removes nothing.

Fix: use `call.removeAllListeners()`. Safe because `Call` instances are held privately by the `Room` and only torn down at close time.

Regression test: [test/room-call-listener-removal](https://github.com/molvqingtai/artico/tree/test/room-call-listener-removal).
